### PR TITLE
Syntax match for variables. 

### DIFF
--- a/client/syntaxes/harbour.tmLanguage.json
+++ b/client/syntaxes/harbour.tmLanguage.json
@@ -71,6 +71,9 @@
 				},
 				{
 					"include": "#numbers"
+				},
+				{
+					"include": "#variable-name"
 				}
 			]
 		},

--- a/client/syntaxes/harbour.tmLanguage.json
+++ b/client/syntaxes/harbour.tmLanguage.json
@@ -295,7 +295,7 @@
 			"patterns": [
 				{
 					"name": "variable.other.readwrite.harbour",
-					"match": "(?i)\\b([a-z_]\\w*)\\b"
+					"match": "\\b(s_)?(mtx)?[a,b,c,d,h,l,n,o,u,x][A-Z][A-Za-z0-9_]*\\b"
 				}
 			]
 		},


### PR DESCRIPTION
Where I work we started to use your extension, but we needed the syntax highlighting for variables too. 
I used the same regex the Atom extension uses for variables and included the pattern for inline-statements.
Changing the regex was necessary as the previous regex was capturing reserved words like say get read valid picture.

Example:
Before
![](https://cdn.discordapp.com/attachments/483422896807608321/726458441253519360/unknown.png)
After
![](https://cdn.discordapp.com/attachments/483422896807608321/726458588582772766/unknown.png)

